### PR TITLE
Fix: CSS Rendering for Example Sites

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -16,8 +16,3 @@ module:
     # used to source the base theme for academy.
     - path: github.com/layer5io/academy-theme
       disable: false
-
-      mounts:
-        - source: layouts
-          target: layouts
-          disableWatch: false


### PR DESCRIPTION
**Notes for Reviewers**

I've removed the `mount` content from the Hugo YAML file. It had a bug that prevented CSS from rendering when running `make site` for example files. 
If concerned about custom shortcodes from example repos not rendering, I've tested that they won't be overwritten.
<img width="956" height="500" alt="2aa7c02e52c3ff55a0b174cc62b6551" src="https://github.com/user-attachments/assets/9f8334ac-0264-48bb-b9a5-832560756aff" />

Before:
<img width="956" height="500" alt="5dd068d0890d0d8225e439584b52419" src="https://github.com/user-attachments/assets/0fdadc82-b678-4d1f-aab5-f5c29e268baa" />

After:
<img width="956" height="500" alt="b8301f15c8d09c13e9da83db87ce1ee" src="https://github.com/user-attachments/assets/ba1206e2-ad9d-4132-87b7-cdcb57789a22" />
