### PR TITLE
Remove Print Output

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -2,11 +2,6 @@ baseURL: http://localhost:9876/academy/
 title: Example Academy
 canonifyurls: true
 
-
-# Comment out if you don't want the "print entire section" link enabled.
-outputs:
-  section: [HTML, print, RSS,JSON]
-
 module:
   hugoVersion:
     extended: true


### PR DESCRIPTION
**Notes for Reviewers**

This PR removes the "print" output format from `hugo.yaml`.
