### PR TITLE
fix: Add GitHub Actions workflow to build Hugo PR previews

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,27 @@
+name: Deploy PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build-preview:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Hugo Extended
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: '0.147.9'
+          extended: true
+
+      - name: Install dependencies
+        run: make setup
+
+      - name: Build site for PR preview
+        run: |
+          BASEURL="https://layer5io.github.io/layer5-academy/pr-preview-${{ github.event.pull_request.number }}/"
+          npm run build:preview

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "_hugo-dev": "npm run _hugo -- -e dev -DFE",
     "_local": "npx cross-env HUGO_MODULE_WORKSPACE=docsy.work",
     "_serve": "npm run _hugo-dev -- --minify serve --renderToMemory",
-    "build:preview": "npm run _hugo-dev -- --minify --baseURL \"${DEPLOY_PRIME_URL:-/}\"",
+    "build:preview": "npm run _hugo-dev -- --minify --baseURL \"${BASEURL:-/}\"",
     "build:production": "npm run _hugo -- --minify",
     "build": "npm run _build -- ",
     "check:links:all": "HTMLTEST_ARGS= npm run _check:links",


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #

- Introduce a new GitHub Actions workflow `preview.yml` that builds the Hugo site on pull requests.
- Update `package.json`’s `build:preview` script to use  `BASEURL` environment variable instead of `DEPLOY_PRIME_URL`.



**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
