### PR TITLE
[Automated] Update academy-theme to v0.3.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,6 @@ replace github.com/FortAwesome/Font-Awesome v4.7.0+incompatible => github.com/Fo
 
 require (
 	github.com/FortAwesome/Font-Awesome v4.7.0+incompatible // indirect
-	github.com/layer5io/academy-theme v0.3.4 // indirect
+	github.com/layer5io/academy-theme v0.3.5 // indirect
 	github.com/twbs/bootstrap v5.3.7+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -16,5 +16,7 @@ github.com/layer5io/academy-theme v0.3.2 h1:ZzdY8pvqq91/qoAPhiuY6z37gqbQhsVLhnWg
 github.com/layer5io/academy-theme v0.3.2/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
 github.com/layer5io/academy-theme v0.3.4 h1:fZF2BM5W3/vjLrTrLFL4SQ1s6E7h1on0UVopsEw4tDQ=
 github.com/layer5io/academy-theme v0.3.4/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
+github.com/layer5io/academy-theme v0.3.5 h1:6LV6puez+NrzEWgbxuvgc2IUfyz1LcQsclt5wwkjFXc=
+github.com/layer5io/academy-theme v0.3.5/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
 github.com/twbs/bootstrap v5.3.7+incompatible h1:ea1W8TOWZFkqSK2M0McpgzLiUQVru3bz8aHb0j/XtuM=
 github.com/twbs/bootstrap v5.3.7+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
This PR updates the academy-theme dependency to the latest release version v0.3.5.

Changes:
- Updated go.mod
- Regenerated go.sum

Auto-generated based upon release of a new version of layer5io/academy-theme.