### PR TITLE
[Automated] Update academy-theme to v0.3.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,6 @@ replace github.com/FortAwesome/Font-Awesome v4.7.0+incompatible => github.com/Fo
 
 require (
 	github.com/FortAwesome/Font-Awesome v4.7.0+incompatible // indirect
-	github.com/layer5io/academy-theme v0.3.8 // indirect
+	github.com/layer5io/academy-theme v0.3.9 // indirect
 	github.com/twbs/bootstrap v5.3.7+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -18,11 +18,13 @@ github.com/layer5io/academy-theme v0.3.4 h1:fZF2BM5W3/vjLrTrLFL4SQ1s6E7h1on0UVop
 github.com/layer5io/academy-theme v0.3.4/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
 github.com/layer5io/academy-theme v0.3.5 h1:6LV6puez+NrzEWgbxuvgc2IUfyz1LcQsclt5wwkjFXc=
 github.com/layer5io/academy-theme v0.3.5/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
-github.com/layer5io/academy-theme v0.3.8 h1:TGi/BDD9Rf11W8fLhzMzSlz0BZ7ofLN8WQ0iPR1658A=
-github.com/layer5io/academy-theme v0.3.8/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
-github.com/layer5io/academy-theme v0.3.7 h1:i7ar0YZiCLSY85CjOIySaMhNLDLQ2ldTNwqL4Z6UPJE=
-github.com/layer5io/academy-theme v0.3.7/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
 github.com/layer5io/academy-theme v0.3.6 h1:td3ruHtuAVEJBmzJixThatBpZsz2isU9hH7palpIUzY=
 github.com/layer5io/academy-theme v0.3.6/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
+github.com/layer5io/academy-theme v0.3.7 h1:i7ar0YZiCLSY85CjOIySaMhNLDLQ2ldTNwqL4Z6UPJE=
+github.com/layer5io/academy-theme v0.3.7/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
+github.com/layer5io/academy-theme v0.3.8 h1:TGi/BDD9Rf11W8fLhzMzSlz0BZ7ofLN8WQ0iPR1658A=
+github.com/layer5io/academy-theme v0.3.8/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
+github.com/layer5io/academy-theme v0.3.9 h1:4CU6dmrV7CHDis5riGfvX/CyvulteivB9TQYiMg/EE0=
+github.com/layer5io/academy-theme v0.3.9/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
 github.com/twbs/bootstrap v5.3.7+incompatible h1:ea1W8TOWZFkqSK2M0McpgzLiUQVru3bz8aHb0j/XtuM=
 github.com/twbs/bootstrap v5.3.7+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
This PR updates the academy-theme dependency to the latest release version v0.3.9.

Changes:
- Updated go.mod
- Regenerated go.sum

Auto-generated based upon release of a new version of layer5io/academy-theme.