### PR TITLE
[Automated] Update academy-theme to v0.4.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,6 @@ replace github.com/FortAwesome/Font-Awesome v4.7.0+incompatible => github.com/Fo
 
 require (
 	github.com/FortAwesome/Font-Awesome v4.7.0+incompatible // indirect
-	github.com/layer5io/academy-theme v0.4.6 // indirect
+	github.com/layer5io/academy-theme v0.4.7 // indirect
 	github.com/twbs/bootstrap v5.3.7+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -38,5 +38,7 @@ github.com/layer5io/academy-theme v0.4.4 h1:BDGDQtmhBvj4cxcwJt4/Q43eF26Urp9CyENr
 github.com/layer5io/academy-theme v0.4.4/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
 github.com/layer5io/academy-theme v0.4.6 h1:SYCqM+THVyl5nOEs8WTV4rjoa7d1SZOn+K0gBE0fIu0=
 github.com/layer5io/academy-theme v0.4.6/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
+github.com/layer5io/academy-theme v0.4.7 h1:Wq1uaVZN04rXnrMgX2K37M2xr/yR0I6NiyOW2AZ3DsY=
+github.com/layer5io/academy-theme v0.4.7/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
 github.com/twbs/bootstrap v5.3.7+incompatible h1:ea1W8TOWZFkqSK2M0McpgzLiUQVru3bz8aHb0j/XtuM=
 github.com/twbs/bootstrap v5.3.7+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
This PR updates the academy-theme dependency to the latest release version v0.4.7.

Changes:
- Updated go.mod
- Regenerated go.sum

Auto-generated based upon release of a new version of layer5io/academy-theme.