### PR TITLE
fix: disable Hugo Node security permissions sandboxing for build compatibility

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -16,3 +16,9 @@ module:
     # used to source the base theme for academy.
     - path: github.com/layer5io/academy-theme
       disable: false
+
+security:
+  node:
+    permissions:
+      disable: true
+


### PR DESCRIPTION


Disables Node permission restrictions/sandboxing in Hugo (`security.node.permissions.disable = true`) to prevent build failures on Node 20 and older versions of Node 22 where the `--permission` flag is unsupported by Node.

This ensures that PostCSS builds successfully and compiles the stylesheet (`main.css`), avoiding unstyled pages in local and CI development environments.


**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
