### PR TITLE
[chore]: build and release workflow update to match makefile changes

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -12,10 +12,11 @@ on:
       token:
         description: 'Bearer token'
         required: true
-      academy-name: 
+      academy-name:
+        description: 'Name of the Academy represented by this repo'
         required: false
-        default: "Digital Ocean Academy"
-        type: string        
+        default: 'Layer5 Academy'
+        type: string
       version:
         description: 'Module version'
         required: false
@@ -27,19 +28,29 @@ jobs:
 
     steps:
       - name: Checkout site
-        uses: actions/checkout@v4
-
-      - name: Setup Hugo Extended
-        uses: peaceiris/actions-hugo@v2
+        uses: actions/checkout@v6
         with:
-          hugo-version: '0.158.0'
-          extended: true
+          fetch-depth: 0
+
+      # Required: academy-theme is a Hugo module, so the build needs Go.
+      # 'make build-production' runs check-go and fails fast without it.
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
 
       - name: Install dependencies
         run: make setup
 
       - name: Run production build test
-        run: make build
+        run: make build-production
 
       - name: Publish to layer5 academy
         id: academy
@@ -47,7 +58,7 @@ jobs:
         with:
           orgId: ${{ github.event.inputs.orgId || secrets.ACADEMY_ORG_ID }}
           token: ${{ github.event.inputs.token || secrets.PROVIDER_TOKEN }}
-          academy-name: "Layer5 Academy"
+          academy-name: ${{ github.event.inputs.academy-name || 'Layer5 Academy' }}
           version: ${{ github.event.inputs.version != '' && github.event.inputs.version || github.ref_name }}
 
       - name: Show response


### PR DESCRIPTION
**Notes for Reviewers**
- This PR should be merged after #240 has been merged
- **Added `Setup Go`** — required. `make build-production` → `check-go` hard-fails without it, and Hugo needs Go to resolve the `academy-theme` module.
- **Removed `peaceiris/actions-hugo`** — redundant. `make setup` installs `hugo-extended` into `node_modules/.bin`, and `make build-production` reaches Hugo via `npm run` (which puts `.bin` on `PATH`). Dropping it also removes a second place the Hugo version was pinned. It was pinned to the outdated `@v2`.
- **`make build` → `make build-production`** — the step claims a production build test; `build` is the dev build.
- **`academy-name`** now reads its declared `workflow_dispatch` input (`${{ github.event.inputs.academy-name || 'Layer5 Academy' }}`) instead of being hardcoded, so the input is no longer ignored. The input's default was also corrected from `"Digital Ocean Academy"` to `'Layer5 Academy'` — it had no effect previously because the step hardcoded the value, so published output is unchanged.
- **Added `Setup Node`** (20 + npm cache); `checkout@v4` → `@v6` with `fetch-depth: 0`.

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
