### PR TITLE
[Automated] Update academy-theme to v0.4.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/layer5io/layer5-academy
 
-go 1.24.5
+go 1.26.4
 
 // Uncomment line below when testing changes to the academy theme
 // replace github.com/layer5io/academy-theme v0.1.9 => ../academy-theme
@@ -9,6 +9,6 @@ replace github.com/FortAwesome/Font-Awesome v4.7.0+incompatible => github.com/Fo
 
 require (
 	github.com/FortAwesome/Font-Awesome v4.7.0+incompatible // indirect
-	github.com/layer5io/academy-theme v0.4.17 // indirect
+	github.com/layer5io/academy-theme v0.4.18 // indirect
 	github.com/twbs/bootstrap v5.3.7+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -60,5 +60,7 @@ github.com/layer5io/academy-theme v0.4.16 h1:nrwEIv8mji6sfq7cazyJVhGEoeisqu5RdQ0
 github.com/layer5io/academy-theme v0.4.16/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
 github.com/layer5io/academy-theme v0.4.17 h1:rnTuWwEIyYqtFyqiDz+GZOSTz/Wpud8256+QtH0HYXM=
 github.com/layer5io/academy-theme v0.4.17/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
+github.com/layer5io/academy-theme v0.4.18 h1:czJxqyLtNu2qUkKeJ+ez7uAb4riu9s/4vNAvcsH36mM=
+github.com/layer5io/academy-theme v0.4.18/go.mod h1:oe18PzjKqTv8WptTZx5qbRljga9VUlDpyA2tZdLxWsI=
 github.com/twbs/bootstrap v5.3.7+incompatible h1:ea1W8TOWZFkqSK2M0McpgzLiUQVru3bz8aHb0j/XtuM=
 github.com/twbs/bootstrap v5.3.7+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
This PR updates the academy-theme dependency to the latest release version v0.4.18.

Changes:
- Updated go.mod
- Regenerated go.sum

Auto-generated based upon release of a new version of layer5io/academy-theme.